### PR TITLE
Add DynamoDB abstraction

### DIFF
--- a/server/apis/__tests__/article.test.js
+++ b/server/apis/__tests__/article.test.js
@@ -1,8 +1,13 @@
 // @Flow
 
 import { create, read, update } from '../article';
+import db from '../../db/db';
 
 describe('article', () => {
+  beforeEach(() => {
+    db.init(true);
+  });
+
   test('read should return null for non-exist article request', () => {
     expect.assertions(1);
     return read('nonExist').then((result) => {

--- a/server/db/db.flow.js
+++ b/server/db/db.flow.js
@@ -7,3 +7,9 @@ export type Article = {
   content: string,
   rev: number,
 }
+
+export type CreateArticle = Article;
+export type ReadArticle = {
+  id: string,
+};
+export type UpdateArticle = Article;

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -1,10 +1,31 @@
 // @Flow
 
 import loki from './loki';
+import dynamoDB from './dynamoDB';
 
-const { createArticle, readArticle, updateArticle } = loki;
+import type { CreateArticle, ReadArticle, UpdateArticle, Article } from './db.flow';
+
+let useLoki = false;
+
+const init = (useLokiDB: boolean, awsRegion: string): void => {
+  useLoki = useLokiDB;
+
+  if (!useLoki) {
+    dynamoDB.init(awsRegion);
+  }
+};
+
+const createArticle = async (doc: CreateArticle): Promise<Article> =>
+  useLoki ? loki.createArticle(doc) : dynamoDB.createArticle(doc);
+
+const readArticle = async (doc: ReadArticle): Promise<Article> =>
+  useLoki ? loki.readArticle(doc) : dynamoDB.readArticle(doc);
+
+const updateArticle = async (doc: UpdateArticle): Promise<Article> =>
+  useLoki ? loki.updateArticle(doc) : dynamoDB.updateArticle(doc);
 
 export default {
+  init,
   createArticle,
   readArticle,
   updateArticle,

--- a/server/db/dynamoDB.js
+++ b/server/db/dynamoDB.js
@@ -1,0 +1,80 @@
+// @flow
+
+import AWS from 'aws-sdk';
+
+import type { CreateArticle, ReadArticle, UpdateArticle, Article } from './db.flow';
+
+const file = 'server/db/dynamoDB.js';
+const articleTableName = 'article';
+
+let awsRegion = '';
+let docClientInstance = null;
+
+const init = (region: string) => {
+  awsRegion = region;
+};
+
+const docClient = (): Object => {
+  if (!docClientInstance) {
+    AWS.config.update({
+      region: awsRegion,
+    });
+
+    docClientInstance = new AWS.DynamoDB.DocumentClient();
+  }
+
+  return docClientInstance;
+};
+
+const createArticle = async (doc: CreateArticle): Promise<Article> => {
+  console.log({ file, function: 'createArticle', doc });
+
+  const params = {
+    TableName: articleTableName,
+    Item: doc,
+  };
+
+  return docClient().put(params).promise();
+};
+
+type QueryResult = { Items: Array<Article>, Count: number, ScannedCount: number };
+
+const readArticle = async (doc: ReadArticle): Promise<Article> => {
+  const func = 'readArticle';
+
+  console.log({ file, func, doc });
+
+  const params = {
+    TableName: articleTableName,
+    KeyConditionExpression: 'id = :id',
+    ExpressionAttributeValues: {
+      ':id': doc.id,
+    },
+  };
+
+  try {
+    const result: QueryResult = await docClient().query(params).promise();
+    return result.Items[0];
+  } catch (e) {
+    console.error({ file, func, error: e });
+    return {};
+  }
+};
+
+const updateArticle = (doc: UpdateArticle): Promise<Article> => {
+  console.log({ file, function: 'updateArticle', doc });
+
+  const params = {
+    TableName: articleTableName,
+    Item: doc,
+  };
+
+  return docClient().put(params).promise();
+};
+
+export default {
+  init,
+  createArticle,
+  readArticle,
+  updateArticle,
+};

--- a/server/db/loki.js
+++ b/server/db/loki.js
@@ -4,32 +4,26 @@
 
 import loki from 'lokijs';
 
-import type { Article } from './db.flow.js';
+import type { CreateArticle, ReadArticle, UpdateArticle, Article } from './db.flow';
 
 const db = new loki('local.db');
 const articles = db.addCollection('article');
 
 const file = 'server/db/loki.js';
 
-export type LokiArticle = {
-  id: string,
-  content?: string,
-  revision?: number,
-}
-
-const createArticle = (doc: LokiArticle): boolean => {
+const createArticle = (doc: CreateArticle): boolean => {
   console.log({ file, function: 'createArticle', doc });
 
   return articles.insert(doc);
 };
 
-const readArticle = (doc: LokiArticle): ?Article => {
+const readArticle = (doc: ReadArticle): ?Article => {
   console.log({ file, function: 'readArticle', doc });
 
   return articles.findOne(doc);
 };
 
-const updateArticle = (doc: LokiArticle): boolean => {
+const updateArticle = (doc: UpdateArticle): boolean => {
   console.log({ file, function: 'updateArticle', doc });
 
   return articles.update(doc);


### PR DESCRIPTION
Now dynamoDB is the default and AWS_REGION should be passed to
use it. To use Loki DB instead, DB=loki environment variable
should be set.

Example:
```
AWS_REGION=us-west-2 npm run start:standalone   # to use dynamoDB
DB=loki npm run start:standalone    # to use loki
```