### PR TITLE
Make articleId include slash(/)

### DIFF
--- a/server/app.jsx
+++ b/server/app.jsx
@@ -54,13 +54,13 @@ app.use(session.createSessionMiddleware());
 app.use(express.static(path.join(__dirname, './public')));
 
 // Article APIs
-app.post('/api/article/:id', (req, res) => {
+app.post('/api/article/*?', (req, res) => {
   const func = 'app.post /api/article/:id';
   console.log({ file, func, params: req.params, body: req.body});
 
   const { content } = req.body;
 
-  article.create(req.params.id, content)
+  article.create(req.params[0], content)
     .then(result => res.send(result))
     .catch(error => {
       console.log({ file, func, error });
@@ -68,11 +68,13 @@ app.post('/api/article/:id', (req, res) => {
     });
 });
 
-app.get('/api/article/:id', (req, res) => {
+app.get('/api/article/*?', (req, res) => {
   const func = 'app.get /api/article/:id';
   console.log({ file, func, params: req.params });
 
-  article.read(req.params.id)
+  console.log(req.params);
+
+  article.read(req.params[0])
     .then(result => {
       console.log({ file, func, result });
       res.send(result)
@@ -83,13 +85,13 @@ app.get('/api/article/:id', (req, res) => {
     });
 });
 
-app.put('/api/article/:id', (req, res) => {
+app.put('/api/article/*?', (req, res) => {
   const func = 'app.put /api/article/:id';
   console.log({ file, func, params: req.params, body: req.body });
 
   const { content, rev } = req.body;
 
-  article.update(req.params.id, content, rev)
+  article.update(req.params[0], content, rev)
     .then(result => res.send(result))
     .catch(error => {
       console.log({ file, func, error });

--- a/src/containers/ArticleContainer.jsx
+++ b/src/containers/ArticleContainer.jsx
@@ -7,9 +7,13 @@ import connectWithRouter from '../../modules/connectWithRouter';
 import Article from '../components/Article';
 import { updateArticle } from '../actions/article';
 
+const file = '/src/containers/ArticleContainer';
+
 const ArticleContainer = (props) => {
   const { pageId } = props.match.params;
   const { content, revision, onReadArticle } = props;
+
+  console.log({ file, func: 'ArticleContainer', pageId });
 
   onReadArticle(pageId);
 

--- a/src/containers/MainContainer.jsx
+++ b/src/containers/MainContainer.jsx
@@ -20,8 +20,8 @@ const MainContainer = () => (
           <Route path='/hello' component={Hello}/>
           <Route path='/about' component={About}/>
           <Route exact path='/w' component={ArticleContainer}/>
-          <Route exact path='/w/:pageId' component={ArticleContainer}/>
-          <Route exact path='/edit/:pageId' component={EditContainer}/>
+          <Route exact path='/w/:pageId(.+)' component={ArticleContainer}/>
+          <Route exact path='/edit/:pageId(.+)' component={EditContainer}/>
         </Switch>
       </Col>
     </Row>


### PR DESCRIPTION
This wiki supports hierarchy b/w articles. For example, an article 'ab/cd' is under
the 'ab' article conceptually. For this purpose, article id need to be
able to include slash.

References:
- https://github.com/ReactTraining/react-router/issues/391#issuecomment-294237556
- https://stackoverflow.com/questions/10020099/express-js-routing-optional-spat-param/14481168#comment49246489_29549148