### PR TITLE
Use ReactDOM.hydrate() instead of render()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-filename-extension */
 
 import React from 'react';
-import { render } from 'react-dom';
+import { hydrate } from 'react-dom';
 import './styles/index.css';
 import { Provider } from 'react-redux';
 import createReduxStore from '../modules/store';
@@ -13,7 +13,7 @@ const initialState = window.__INITIAL_STATE__;
 
 const store = createReduxStore(initialState);
 
-render(
+hydrate(
   <Provider store={store}>
     <BrowserRouter>
       <App />


### PR DESCRIPTION
Now React has hydrate function to hydrate server rendered HTML
in client side. render() creates and overwrites current DOM with
new rendered one, but this is unnecessary in the first render(hydrate)
because there must be no difference b/w the existing DOM and the
newly rendered one. hydrate() just attached event handlers to
the existing DOM without rerendering.

Also, using render for the first client side rendering(hydrate) is
being deprecated.

https://reactjs.org/docs/react-dom.html#hydrate